### PR TITLE
WIP: try running cibuildwheel directly

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           platforms: arm64
         if: runner.os == 'Linux'
-      - uses: pypa/cibuildwheel@v2.9.0
+      - run: pipx run cibuildwheel==2.9.0
         env:
           CIBW_SKIP: pp* cp36-* *-musllinux*
           CIBW_ARCHS_MACOS: x86_64 universal2


### PR DESCRIPTION
I'd like to see if this really fixes Meson on Windows before complicating the GHA in cibuildwheel. Could you run the wheel build on this?